### PR TITLE
Add walkthrough script

### DIFF
--- a/cleanup-workshop.sh
+++ b/cleanup-workshop.sh
@@ -28,6 +28,7 @@ if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
     ./gke/cleanup-gke.sh  &> ${WORK_DIR}/cleanup-gke.log &
     #./common/cleanup-tools.sh
     gcloud source repos delete --quiet config-repo
+    rm $HOME/.ssh/id_rsa.nomos.*
     wait
 
     rm -rf $WORK_DIR

--- a/cleanup-workshop.sh
+++ b/cleanup-workshop.sh
@@ -27,6 +27,7 @@ if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
     ./connect-hub/cleanup-remote-gce.sh&> ${WORK_DIR}/cleanup-remote.log &
     ./gke/cleanup-gke.sh  &> ${WORK_DIR}/cleanup-gke.log &
     #./common/cleanup-tools.sh
+    gcloud source repos delete --quiet config-repo
     wait
 
     rm -rf $WORK_DIR

--- a/common/demo-magic.sh
+++ b/common/demo-magic.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#
+# demo-magic.sh
+#
+# Copyright (c) 2015 Paxton Hare
+#
+# This script lets you script demos in bash. It runs through your demo script when you press
+# ENTER. It simulates typing and runs commands.
+#
+###############################################################################
+
+# the speed to "type" the text
+TYPE_SPEED=20
+
+# no wait after "p" or "pe"
+NO_WAIT=false
+
+# if > 0, will pause for this amount of seconds before automatically proceeding with any p or pe
+PROMPT_TIMEOUT=0
+
+# don't show command number unless user specifies it
+SHOW_CMD_NUMS=false
+
+
+# handy color vars for pretty prompts
+BLACK="\033[0;30m"
+BLUE="\033[0;34m"
+GREEN="\033[0;32m"
+GREY="\033[0;90m"
+CYAN="\033[0;36m"
+RED="\033[0;31m"
+PURPLE="\033[0;35m"
+BROWN="\033[0;33m"
+WHITE="\033[1;37m"
+COLOR_RESET="\033[0m"
+
+C_NUM=0
+
+# prompt and command color which can be overriden
+DEMO_PROMPT="$ "
+DEMO_CMD_COLOR=$WHITE
+DEMO_COMMENT_COLOR=$GREY
+
+##
+# prints the script usage
+##
+function usage() {
+  echo -e ""
+  echo -e "Usage: $0 [options]"
+  echo -e ""
+  echo -e "\tWhere options is one or more of:"
+  echo -e "\t-h\tPrints Help text"
+  echo -e "\t-d\tDebug mode. Disables simulated typing"
+  echo -e "\t-n\tNo wait"
+  echo -e "\t-w\tWaits max the given amount of seconds before proceeding with demo (e.g. '-w5')"
+  echo -e ""
+}
+
+##
+# wait for user to press ENTER
+# if $PROMPT_TIMEOUT > 0 this will be used as the max time for proceeding automatically
+##
+function wait() {
+  if [[ "$PROMPT_TIMEOUT" == "0" ]]; then
+    read -rs
+  else
+    read -rst "$PROMPT_TIMEOUT"
+  fi
+}
+
+##
+# print command only. Useful for when you want to pretend to run a command
+#
+# takes 1 param - the string command to print
+#
+# usage: p "ls -l"
+#
+##
+function p() {
+  if [[ ${1:0:1} == "#" ]]; then
+    cmd=$DEMO_COMMENT_COLOR$1$COLOR_RESET
+  else
+    cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
+  fi
+
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+  
+  # show command number is selected
+  if $SHOW_CMD_NUMS; then
+   printf "[$((++C_NUM))] $x"
+  else
+   printf "$x"
+  fi
+
+  # wait for the user to press a key before typing the command
+  if !($NO_WAIT); then
+    wait
+  fi
+
+  if [[ -z $TYPE_SPEED ]]; then
+    echo -en "$cmd"
+  else
+    echo -en "$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
+  fi
+
+  # wait for the user to press a key before moving on
+  if !($NO_WAIT); then
+    wait
+  fi
+  echo ""
+}
+
+##
+# Prints and executes a command
+#
+# takes 1 parameter - the string command to run
+#
+# usage: pe "ls -l"
+#
+##
+function pe() {
+  # print the command
+  p "$@"
+
+  # execute the command
+  eval "$@"
+}
+
+##
+# Enters script into interactive mode
+#
+# and allows newly typed commands to be executed within the script
+#
+# usage : cmd
+#
+##
+function cmd() {
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+  printf "$x\033[0m"
+  read command
+  eval "${command}"
+}
+
+
+function check_pv() {
+  command -v pv >/dev/null 2>&1 || {
+
+    echo ""
+    echo -e "${RED}##############################################################"
+    echo "# HOLD IT!! I require pv but it's not installed.  Aborting." >&2;
+    echo -e "${RED}##############################################################"
+    echo ""
+    echo -e "${COLOR_RESET}Installing pv:"
+    echo ""
+    echo -e "${BLUE}Mac:${COLOR_RESET} $ brew install pv"
+    echo ""
+    echo -e "${BLUE}Other:${COLOR_RESET} http://www.ivarch.com/programs/pv.shtml"
+    echo -e "${COLOR_RESET}"
+    exit 1;
+  }
+}
+
+check_pv
+#
+# handle some default params
+# -h for help
+# -d for disabling simulated typing
+#
+while getopts ":dhncw:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 1
+      ;;
+    d)
+      unset TYPE_SPEED
+      ;;
+    n)
+      NO_WAIT=true
+      ;;
+    c)
+      SHOW_CMD_NUMS=true
+      ;;
+    w)
+      PROMPT_TIMEOUT=$OPTARG
+      ;;
+  esac
+done

--- a/walkthough-workshop.sh
+++ b/walkthough-workshop.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. common/demo-magic.sh
+
+pe "gcloud services enable \
+    cloudresourcemanager.googleapis.com \
+    container.googleapis.com \
+    gkeconnect.googleapis.com \
+    gkehub.googleapis.com \
+    serviceusage.googleapis.com \
+    sourcerepo.googleapis.com \
+    --async"
+
+pe "git clone https://github.com/GoogleCloudPlatform/anthos-workshop.git anthos-workshop"
+
+# Initial build
+pe "cd anthos-workshop"
+pe "source ./env"
+pe "source ./bootstrap-workshop.sh"
+pe "source ./service-mesh/enable-service-mesh.sh"
+pe "kubectx remote"
+pe "kubectl get nodes"
+
+# Environment
+pe "export PROJECT=$(gcloud config get-value project)"
+pe "export GKE_CONNECT_SA=anthos-connect"
+pe "export GKE_SA_CREDS=$WORK_DIR/$GKE_CONNECT_SA-creds.json"
+
+pe "gcloud projects add-iam-policy-binding $PROJECT \
+    --member=\"serviceAccount:$GKE_CONNECT_SA@$PROJECT.iam.gserviceaccount.com\" \
+    --role=\"roles/gkehub.connect\""
+
+pe "gcloud iam service-accounts keys create $GKE_SA_CREDS \
+  --iam-account=$GKE_CONNECT_SA@$PROJECT.iam.gserviceaccount.com \
+  --project=$PROJECT"
+
+pe "export REMOTE_CLUSTER_NAME_BASE=remote"
+pe "export REMOTE_CLUSTER_NAME=$REMOTE_CLUSTER_NAME_BASE.k8s.local"
+pe "export REMOTE_KUBECONFIG=$WORK_DIR/remote.context"
+
+pe "export GKE_CONNECT_SA=anthos-connect"
+pe "export GKE_SA_CREDS=$WORK_DIR/$GKE_CONNECT_SA-creds.json"
+pe "kubectx remote"
+
+# Cluster registration
+pe "gcloud alpha container hub register-cluster $REMOTE_CLUSTER_NAME_BASE \
+ --context=$REMOTE_CLUSTER_NAME \
+ --service-account-key-file=$GKE_SA_CREDS \
+ --kubeconfig-file=$REMOTE_KUBECONFIG \
+ --docker-image=gcr.io/gkeconnect/gkeconnect-gce:gkeconnect_20190508_03_00 \
+ --project=$PROJECT"
+
+pe "export KSA=remote-admin-sa"
+pe "kubectl create serviceaccount $KSA"
+pe "kubectl create clusterrolebinding ksa-admin-binding \
+    --clusterrole cluster-admin \
+    --serviceaccount default:$KSA"
+
+pe "printf \"\n$(kubectl --kubeconfig=$REMOTE_KUBECONFIG describe secret $KSA | sed -ne 's/^token: *//p')\n\n\""
+
+p "Now use the GKE console to log in to the cluster with the token above"
+p "============================================================"
+
+# Config management
+pe "export PROJECT=$(gcloud config get-value project)"
+
+pe "cd $HOME"
+pe "export GCLOUD_ACCOUNT=$(gcloud config get-value account)"
+pe "export REPO_URL=https://source.developers.google.com/p/${PROJECT}/r/config-repo"
+
+pe "git clone https://github.com/cgrant/config-repo config-repo"
+pe "cd config-repo"
+pe "git remote remove origin"
+pe "git config credential.helper gcloud.sh"
+pe "git remote add origin $REPO_URL"
+
+pe "gcloud source repos create config-repo"
+pe "git push -u origin master"
+
+pe "ssh-keygen -t rsa -b 4096 \
+-C \"$GCLOUD_ACCOUNT\" \
+-N '' \
+-f $HOME/.ssh/id_rsa.nomos"
+
+pe "kubectx central"
+pe "kubectl create secret generic git-creds \
+--namespace=config-management-system \
+--from-file=ssh=$HOME/.ssh/id_rsa.nomos"
+
+pe "kubectx remote"
+pe "kubectl create secret generic git-creds \
+--namespace=config-management-system \
+--from-file=ssh=$HOME/.ssh/id_rsa.nomos"
+
+p "Now register the public key in the Cloud Source Repositories console"
+
+p "============================================================"
+
+# Review the structure
+pe "tree . "
+pe "echo $REPO_URL"
+pe "cat $BASE_DIR/config-management/config_sync.yaml"
+
+pe "export REMOTE=remote"
+pe "export CENTRAL=central"
+pe "REPO_URL=ssh://${GCLOUD_ACCOUNT}@source.developers.google.com:2022/p/${PROJECT}/r/config-repo"
+
+pe "kubectx $REMOTE"
+pe "cat $BASE_DIR/config-management/config_sync.yaml | \
+  sed 's|<REPO_URL>|'\"$REPO_URL\"'|g' | \
+  sed 's|<CLUSTER_NAME>|'\"$REMOTE\"'|g' | \
+  sed 's|none|ssh|g' | \
+  kubectl apply -f - "
+
+pe "kubectx $CENTRAL"
+pe "cat $BASE_DIR/config-management/config_sync.yaml | \
+  sed 's|<REPO_URL>|'\"$REPO_URL\"'|g' | \
+  sed 's|<CLUSTER_NAME>|'\"$CENTRAL\"'|g' | \
+  sed 's|none|ssh|g' | \
+  kubectl apply -f - "
+
+pe "mkdir namespaces/checkout"
+
+pe "cat <<EOF > namespaces/checkout/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: checkout
+EOF"
+
+pe "tree ." 
+
+pe "export EMAIL=$(gcloud config get-value account)"
+pe "git config --global user.email \"$EMAIL\""
+pe "git config --global user.name \"$USER\""
+
+pe "git add . && git commit -m 'adding checkout namespace'"
+pe "git push origin master"
+
+pe "kubectl --context remote delete ns checkout"
+pe "cd $HOME/config-repo"
+pe "mkdir clusterregistry"
+
+pe "cat <<EOF > clusterregistry/cluster-remote.yaml
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: remote
+  labels:
+    env: remote
+    lifecycle: prod
+EOF"
+
+pe "cat <<EOF > clusterregistry/cluster-central.yaml
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: central
+  labels:
+    env: central
+    lifecycle: prod
+EOF"
+
+pe "git add . && git commit -m 'add ClusterSelector and Cluster resource definitions for remote and central'"
+pe "git push origin master"
+
+pe "cat <<EOF > clusterregistry/clusterselector-remote.yaml
+kind: ClusterSelector
+apiVersion: configmanagement.gke.io/v1
+metadata:
+  name: selector-env-remote
+spec:
+  selector:
+    matchLabels:
+      env: remote
+      lifecycle: prod
+EOF"
+
+pe "cat <<EOF > namespaces/checkout/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: checkout
+  annotations:
+    configmanagement.gke.io/cluster-selector: selector-env-remote
+EOF"
+
+pe "git add . && git commit -m 'modify the checkout namespace'"
+pe "git push origin master"
+
+p "============================================================"
+
+pe "cd $BASE_DIR"
+pe "./hybrid-multicluster/istio-dns.sh"
+pe "kubectl --context central -n kube-system get configmap kube-dns -o json | jq '.data' "
+pe "kubectl --context central -n istio-system get configmap coredns -o json | jq -r '.data.Corefile'"
+pe "./hybrid-multicluster/istio-deploy-hipster.sh"
+
+pe "kubectl --context central -n hipster2 get all"
+pe "kubectl --context remote -n hipster1 get all"
+
+pe "kubectl --context central -n hipster2 get deploy frontend -ojson | jq -r '[.spec.template.spec.containers[].env[]]'"
+pe "kubectl --context remote -n hipster1 get deploy checkoutservice -ojson | jq -r '[.spec.template.spec.containers[].env[]]'"
+
+pe "kubectl --context central -n hipster2 get serviceentries"
+pe "kubectl --context remote -n hipster1 get serviceentries"
+
+pe "kubectl --context central -n hipster2 get serviceentry checkoutservice-entry -ojson | jq '.spec.endpoints'"
+pe "kubectl --context central -n hipster2 get gateway -ojson | jq '.items[].spec'"
+pe "kubectl --context central get -n istio-system service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'"
+
+p "============================================================"
+
+pe "./hybrid-multicluster/istio-connect.sh"
+pe "./hybrid-multicluster/istio-migrate-hipster.sh"
+
+pe "kubectl --context central -n hipster2 get deploy frontend -ojson | jq -r '[.spec.template.spec.containers[].env[]]'"

--- a/walkthough-workshop.sh
+++ b/walkthough-workshop.sh
@@ -25,8 +25,6 @@ pe "gcloud services enable \
     sourcerepo.googleapis.com \
     --async"
 
-pe "git clone https://github.com/GoogleCloudPlatform/anthos-workshop.git anthos-workshop"
-
 # Initial build
 pe "cd anthos-workshop"
 pe "source ./env"

--- a/walkthough-workshop.sh
+++ b/walkthough-workshop.sh
@@ -26,7 +26,6 @@ pe "gcloud services enable \
     --async"
 
 # Initial build
-pe "cd anthos-workshop"
 pe "source ./env"
 pe "source ./bootstrap-workshop.sh"
 pe "source ./service-mesh/enable-service-mesh.sh"

--- a/walkthough-workshop.sh
+++ b/walkthough-workshop.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+sudo apt-get -qq install pv
 . common/demo-magic.sh
 
 pe "gcloud services enable \


### PR DESCRIPTION
This PR uses Demo Magic to provide a "click-through"-able demo of the workshop flow, `walkthrough-workshop.sh`. Note that this includes command line actions, but obviously not the steps that need to be completed in the GCP web UI (I have written prompts for these). The main script has been created using substitution from the workshop document, so any changes made there will need to be manually rolled back into this sequence of steps to ensure consistency. If you run with the "-d" switch you won't need to wait for the commands to be "typed", you can just hit enter continually for speed. One thing to bear in mind is that the required environment variables will only be set within the walkthrough environment, so you will have to stick to the script --  both literally and figuratively.