### PR TITLE
Update to 1.12 to handle minor releases

### DIFF
--- a/gke/provision-gke.sh
+++ b/gke/provision-gke.sh
@@ -18,7 +18,7 @@
 export PROJECT=$(gcloud config get-value project)
 export WORK_DIR=${WORK_DIR:="${PWD}/workdir"}
 
-export CLUSTER_VERSION="1.12.6-gke.10"
+export CLUSTER_VERSION="1.12"
 export CLUSTER_NAME="central"
 export CLUSTER_ZONE="us-central1-b"
 export CLUSTER_KUBECONFIG=$WORK_DIR/central.context


### PR DESCRIPTION
Lock it to a supported GKE 1.12 version, handling minor revision updates.