### PR TITLE
Replace deprecated GKE cluster version.

### DIFF
--- a/env
+++ b/env
@@ -12,7 +12,7 @@
     export ISTIO_VERSION=1.3.2
     export KUBECTX_VERSION=v0.7.0
     export HELM_VERSION=v2.14.3
-    export CLUSTER_VERSION=1.15.7-gke.23
+    export CLUSTER_VERSION=1.15.9-gke.8
     export KOPS_VERSION=1.15.0
 
 


### PR DESCRIPTION
1.15.7-gke.23 is no longer supported.