### PR TITLE
Only specify the minor k8s version for GKE.

### DIFF
--- a/env
+++ b/env
@@ -12,7 +12,7 @@
     export ISTIO_VERSION=1.3.2
     export KUBECTX_VERSION=v0.7.0
     export HELM_VERSION=v2.14.3
-    export CLUSTER_VERSION=1.15.9-gke.8
+    export CLUSTER_VERSION=1.15
     export KOPS_VERSION=1.15.0
 
 


### PR DESCRIPTION
the `--cluster-version` flag supports specifying only the minor version, allowing the server to default the patch version. GKE rotates through supported patch versions fairly regularly, especially the `-gke.x` versions, but will continue supporting 1.15 for at least a quarter or so, so this should keep this workshop functional for a while.