### PR TITLE
Update kops to v1.16.0

### DIFF
--- a/env
+++ b/env
@@ -13,7 +13,7 @@
     export KUBECTX_VERSION=v0.7.0
     export HELM_VERSION=v2.14.3
     export CLUSTER_VERSION=1.15
-    export KOPS_VERSION=1.15.0
+    export KOPS_VERSION=v1.16.0
 
 
 ## Setting variables for GKE


### PR DESCRIPTION
Kops 1.15 has issue with cloud storage MD5 hash, new version works fine in this lab.

Solves #54