### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/gke/provision-gke.sh
+++ b/gke/provision-gke.sh
@@ -29,6 +29,7 @@ else
     echo "Creating cluster..."
     gcloud beta container clusters create ${CLUSTER_NAME} --zone ${CLUSTER_ZONE} \
         --username "admin" \
+        --machine-type "n1-standard-4" \        
         --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
         --num-nodes "2" \
         --enable-autoscaling --min-nodes 2 --max-nodes 8 \

--- a/gke/provision-gke.sh
+++ b/gke/provision-gke.sh
@@ -29,9 +29,6 @@ else
     echo "Creating cluster..."
     gcloud beta container clusters create ${CLUSTER_NAME} --zone ${CLUSTER_ZONE} \
         --username "admin" \
-        --machine-type "n1-standard-4" \
-        --image-type "COS" \
-        --disk-size "100" \
         --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
         --num-nodes "2" \
         --enable-autoscaling --min-nodes 2 --max-nodes 8 \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.